### PR TITLE
Add .planning to gitignore and document critical git rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Thumbs.db
 # Claude Code
 .claude/settings.local.json
 
+# Planning & analysis (local reference only)
+.planning/
+
 # Obsidian vault files (except plugins we're developing)
 .obsidian/
 !.obsidian/plugins/obsidian-metadata-tool/


### PR DESCRIPTION
Add .planning/ to .gitignore (local analysis only)

Document critical git workflow rules in CLAUDE.md:
- Never commit to main without explicit approval
- Always ask before committing
- Follow git-workflow skill strictly
- No force pushes to main