### PR TITLE
Add .planning to gitignore and document critical git rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to AI agents when working with code in this repository.
 
+## Critical Rules
+
+### Git Workflow
+- **NEVER commit to main without explicit approval**
+- Ask before committing anything
+- Propose changes and wait for go-ahead before git operations
+- Follow the git-workflow skill strictly
+- Do not force push to main
+
 ## Project Overview
 
 Metadator: An Obsidian plugin for automatically generating metadata (tags, descriptions, titles) for your notes using the Anthropic Claude API.


### PR DESCRIPTION
- Add .planning/ to .gitignore (local analysis only)
- Document critical git workflow rules in AGENTS.md:
  - Never commit to main without explicit approval
  - Always ask before committing
  - Follow git-workflow skill strictly
  - No force pushes to main