### PR TITLE
Add Claude Code automations for project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(echo \"$CLAUDE_TOOL_INPUT\" | grep -o '\"file_path\":\"[^\"]*\"' | head -1 | sed 's/\"file_path\":\"//;s/\"//'); if echo \"$f\" | grep -q 'src/.*\\.ts$' && ! echo \"$f\" | grep -q '\\.test\\.ts$'; then t=\"${f%.ts}.test.ts\"; [ -f \"$t\" ] && bun test \"$t\" 2>&1 | tail -5; fi",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/deploy-test/SKILL.md
+++ b/.claude/skills/deploy-test/SKILL.md
@@ -1,0 +1,15 @@
+# Deploy Test
+
+Build and deploy the plugin to the test vault.
+
+## Steps
+
+1. Run `bun run build` (includes typecheck + lint)
+2. Run `bun test`
+3. Run `bun run deploy` to copy to notes vault
+4. Remind user to reload Obsidian (Cmd+R)
+
+## Rules
+
+- Abort if build or tests fail
+- Report any new lint warnings

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,20 @@
+# Release
+
+Orchestrate the Metadator release process.
+
+## Steps
+
+1. Ask for the new version (or accept as argument)
+2. Update version in package.json
+3. Run `bun run version` to sync manifest.json and versions.json
+4. Run `bun run validate` to confirm everything passes
+5. Run `bun test` to confirm tests pass
+6. Stage and commit: `chore: bump version to X.Y.Z`
+7. Create git tag: `X.Y.Z`
+8. **Stop and confirm** before pushing — remind user that push triggers GitHub Actions release
+
+## Rules
+
+- Never push without explicit approval
+- Abort if validate or tests fail
+- Use semantic versioning


### PR DESCRIPTION
## Summary
- **Auto-test hook**: project-level PostToolUse hook that runs the matching `.test.ts` file when a source file in `src/` is edited
- **`/release` skill**: orchestrates the full release workflow — version bump, sync, validate, test, commit, and tag
- **`/deploy-test` skill**: build + test + deploy to the notes vault in one step

## Test plan
- [ ] Edit a source file in `src/` and verify the auto-test hook runs the corresponding test
- [ ] Invoke `/release` and confirm it follows the documented steps
- [ ] Invoke `/deploy-test` and confirm build, test, and deploy execute in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)