### PR TITLE
chore: converge CI and build config across plugins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,4 +17,5 @@ jobs:
           bun-version: latest
 
       - run: bun install
+      - run: bun audit --audit-level=critical
       - run: bun run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
+    "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "@types/tern": ["@types/tern@0.23.9", "", { "dependencies": { "@types/estree": "*" } }, "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw=="],
 
@@ -74,5 +74,7 @@
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
+    "bun-types/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "type": "module",
   "scripts": {
+    "audit": "bun audit --audit-level=critical",
     "dev": "bun run build.ts --watch",
     "build": "bun run check && bun run build.ts",
     "check": "bun run typecheck && biome check .",
@@ -23,7 +24,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",
     "@types/bun": "^1.3.10",
-    "@types/node": "^25.3.5",
+    "@types/node": "^25.4.0",
     "obsidian": "^1.12.3",
     "typescript": "^5.9.3"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "build.ts", "version-bump.ts"]
+  "include": ["src/**/*.ts", "build.ts", "version-bump.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `bun audit --audit-level=critical` script and CI step
- Add `permissions: contents: write` to release workflow
- Add tsconfig test file exclusion (`src/**/*.test.ts`)
- Add `dependabot.yml` where missing
- Update dependencies to latest

Part of a cross-repo convergence to share best practices across all Obsidian plugins.

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] `bun run audit` passes
- [x] `bun test` passes (where tests exist)
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)