### PR TITLE
chore: bump softprops/action-gh-release from v2 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           bun run build
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             main.js


### PR DESCRIPTION
## Summary

- Bumps `softprops/action-gh-release` from `@v2` to `@v3`. v3.0.0 was released 2026-04-12 with the sole change of moving the action runtime to Node 24, addressing the deprecation warning that surfaced during the 2.0.1 release run.
- Same public API — `files:`, `fail_on_unmatched_files:`, `GITHUB_TOKEN` env all unchanged.

## Test plan

- [ ] CI on this PR
- [ ] Next release tag triggers `release.yml` without the Node 20 deprecation warning