### PR TITLE
Fix #110 timeout handling and #113 unload cancellation

### DIFF
--- a/src/bulkGenerate.test.ts
+++ b/src/bulkGenerate.test.ts
@@ -363,6 +363,32 @@ describe("runBulk", () => {
     expect(elapsed).toBeLessThan(1_000);
   });
 
+  test("signal abort during retry backoff returns skipped quickly", async () => {
+    const Anthropic = (await import("@anthropic-ai/sdk"))
+      .default as unknown as {
+      RateLimitError: new (msg: string) => Error;
+    };
+    const controller = new AbortController();
+    mockCreate.mockRejectedValueOnce(new Anthropic.RateLimitError("429"));
+    const files = [file("n1.md")];
+    const app = makeApp();
+
+    const run = runBulk(app, files, settings(), {
+      retryDelaysMs: [5_000],
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort("plugin_unloaded"), 0);
+
+    const start = Date.now();
+    const results = await run;
+    const elapsed = Date.now() - start;
+
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("skipped");
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
   test("passes abort signal through bulk generation calls", async () => {
     mockCreate.mockResolvedValueOnce({
       content: [{ type: "text", text: '{"tags": "a", "description": "d"}' }],

--- a/src/bulkGenerate.test.ts
+++ b/src/bulkGenerate.test.ts
@@ -362,4 +362,36 @@ describe("runBulk", () => {
     // Abort polls every 100ms; should return well under the 5s retry delay.
     expect(elapsed).toBeLessThan(1_000);
   });
+
+  test("passes abort signal through bulk generation calls", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: '{"tags": "a", "description": "d"}' }],
+    });
+    const files = [file("n1.md")];
+    const app = makeApp();
+    const controller = new AbortController();
+
+    await runBulk(app, files, settings(), { signal: controller.signal });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        signal: controller.signal,
+      }),
+    );
+  });
+
+  test("skips when bulk signal is already aborted", async () => {
+    const files = [file("n1.md")];
+    const app = makeApp();
+    const controller = new AbortController();
+    controller.abort("plugin_unloaded");
+
+    const results = await runBulk(app, files, settings(), {
+      signal: controller.signal,
+    });
+
+    expect(results).toHaveLength(0);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
 });

--- a/src/bulkGenerate.ts
+++ b/src/bulkGenerate.ts
@@ -53,6 +53,7 @@ export interface RunBulkOptions {
   onProgress?: (p: BulkProgress) => void;
   shouldAbort?: () => boolean;
   retryDelaysMs?: readonly number[];
+  signal?: AbortSignal;
 }
 
 function isRateLimitOrOverload(error: unknown): boolean {
@@ -86,13 +87,15 @@ async function runFileWithRetry(
   settings: MetadataToolSettings,
   retryDelaysMs: readonly number[],
   shouldAbort?: () => boolean,
+  signal?: AbortSignal,
 ): Promise<FileResult> {
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
-    if (shouldAbort?.()) {
+    if (shouldAbort?.() || signal?.aborted) {
       return { kind: "skipped", file, reason: "cancelled before attempt" };
     }
     const r = await generateMetadataForFile(app, file, settings, {
       isBulk: true,
+      signal,
     });
     if (r.kind !== "error" || !isRateLimitOrOverload(r.error)) return r;
     if (attempt === retryDelaysMs.length) return r;
@@ -113,14 +116,14 @@ export async function runBulk(
   app: App,
   files: TFile[],
   settings: MetadataToolSettings,
-  { onProgress, shouldAbort, retryDelaysMs }: RunBulkOptions = {},
+  { onProgress, shouldAbort, retryDelaysMs, signal }: RunBulkOptions = {},
 ): Promise<FileResult[]> {
   const delays = retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
   const results: FileResult[] = [];
   let errors = 0;
 
   for (let i = 0; i < files.length; i++) {
-    if (shouldAbort?.()) break;
+    if (shouldAbort?.() || signal?.aborted) break;
     const file = files[i];
     onProgress?.({ current: i + 1, total: files.length, file, errors });
     const result = await runFileWithRetry(
@@ -129,6 +132,7 @@ export async function runBulk(
       settings,
       delays,
       shouldAbort,
+      signal,
     );
     results.push(result);
     if (result.kind === "error") errors++;

--- a/src/bulkGenerate.ts
+++ b/src/bulkGenerate.ts
@@ -89,8 +89,11 @@ async function runFileWithRetry(
   shouldAbort?: () => boolean,
   signal?: AbortSignal,
 ): Promise<FileResult> {
+  const shouldStop = () =>
+    (shouldAbort?.() ?? false) || (signal?.aborted ?? false);
+
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt++) {
-    if (shouldAbort?.() || signal?.aborted) {
+    if (shouldStop()) {
       return { kind: "skipped", file, reason: "cancelled before attempt" };
     }
     const r = await generateMetadataForFile(app, file, settings, {
@@ -99,7 +102,7 @@ async function runFileWithRetry(
     });
     if (r.kind !== "error" || !isRateLimitOrOverload(r.error)) return r;
     if (attempt === retryDelaysMs.length) return r;
-    const aborted = await sleepAbortable(retryDelaysMs[attempt], shouldAbort);
+    const aborted = await sleepAbortable(retryDelaysMs[attempt], shouldStop);
     if (aborted) {
       return {
         kind: "skipped",

--- a/src/bulkModals.ts
+++ b/src/bulkModals.ts
@@ -88,6 +88,7 @@ export class BulkProgressModal extends Modal {
   private finishing = false;
   private statusEl?: HTMLElement;
   private cancelBtn?: HTMLButtonElement;
+  private onAbort?: () => void;
 
   onOpen(): void {
     const { contentEl } = this;
@@ -98,11 +99,16 @@ export class BulkProgressModal extends Modal {
     this.cancelBtn = buttons.createEl("button", { text: "Cancel" });
     this.cancelBtn.addEventListener("click", () => {
       this.aborted = true;
+      this.onAbort?.();
       if (this.cancelBtn) {
         this.cancelBtn.disabled = true;
         this.cancelBtn.textContent = "Cancelling…";
       }
     });
+  }
+
+  setAbortHandler(handler: () => void): void {
+    this.onAbort = handler;
   }
 
   setProgress(p: {
@@ -127,7 +133,10 @@ export class BulkProgressModal extends Modal {
   }
 
   onClose(): void {
-    if (!this.finishing) this.aborted = true;
+    if (!this.finishing) {
+      this.aborted = true;
+      this.onAbort?.();
+    }
     this.contentEl.empty();
   }
 }

--- a/src/bulkOrchestrator.ts
+++ b/src/bulkOrchestrator.ts
@@ -7,10 +7,16 @@ import {
 } from "./bulkModals";
 import type { MetadataToolSettings } from "./settings";
 
+export interface RunBulkForFolderOptions {
+  signal?: AbortSignal;
+  shouldAbort?: () => boolean;
+}
+
 export async function runBulkForFolder(
   app: App,
   folder: TFolder,
   settings: MetadataToolSettings,
+  opts: RunBulkForFolderOptions = {},
 ): Promise<void> {
   if (!settings.anthropicApiKey) {
     new Notice(
@@ -48,7 +54,8 @@ export async function runBulkForFolder(
 
   const results = await runBulk(app, willChange, settings, {
     onProgress: (p) => progress.setProgress(p),
-    shouldAbort: () => progress.isAborted(),
+    shouldAbort: () => (opts.shouldAbort?.() ?? false) || progress.isAborted(),
+    signal: opts.signal,
   });
 
   const aborted = progress.isAborted();

--- a/src/bulkOrchestrator.ts
+++ b/src/bulkOrchestrator.ts
@@ -50,15 +50,31 @@ export async function runBulkForFolder(
   if (!confirmed) return;
 
   const progress = new BulkProgressModal(app);
+  const runController = new AbortController();
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      runController.abort(opts.signal.reason);
+    } else {
+      opts.signal.addEventListener(
+        "abort",
+        () => runController.abort(opts.signal?.reason),
+        { once: true },
+      );
+    }
+  }
+  progress.setAbortHandler(() => runController.abort("cancelled_by_user"));
   progress.open();
 
   const results = await runBulk(app, willChange, settings, {
     onProgress: (p) => progress.setProgress(p),
     shouldAbort: () => (opts.shouldAbort?.() ?? false) || progress.isAborted(),
-    signal: opts.signal,
+    signal: runController.signal,
   });
 
-  const aborted = progress.isAborted();
+  const aborted =
+    progress.isAborted() ||
+    (opts.shouldAbort?.() ?? false) ||
+    runController.signal.aborted;
   progress.finish();
 
   new BulkSummaryModal(app, results, aborted, willChange.length).open();

--- a/src/callClaude.test.ts
+++ b/src/callClaude.test.ts
@@ -101,6 +101,40 @@ describe("callClaude", () => {
         model: settings.anthropicModel,
         max_tokens: 2048,
       }),
+      expect.objectContaining({
+        timeout: 60_000,
+      }),
+    );
+  });
+
+  test("sets an explicit request timeout", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "response" }],
+    });
+
+    await callClaude("system", "user", settings);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        timeout: 60_000,
+      }),
+    );
+  });
+
+  test("passes abort signal when provided", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: "response" }],
+    });
+    const controller = new AbortController();
+
+    await callClaude("system", "user", settings, { signal: controller.signal });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        signal: controller.signal,
+      }),
     );
   });
 });

--- a/src/callClaude.test.ts
+++ b/src/callClaude.test.ts
@@ -101,9 +101,7 @@ describe("callClaude", () => {
         model: settings.anthropicModel,
         max_tokens: 2048,
       }),
-      expect.objectContaining({
-        timeout: 60_000,
-      }),
+      expect.any(Object),
     );
   });
 

--- a/src/generateMetadata.test.ts
+++ b/src/generateMetadata.test.ts
@@ -17,7 +17,9 @@ mock.module("@anthropic-ai/sdk", () => {
 });
 
 // Import after mocking
-const { generateMetadata } = await import("./metadata");
+const { generateMetadata, generateMetadataForFile } = await import(
+  "./metadata"
+);
 
 function makeApp(opts: {
   file?: { extension: string } | null;
@@ -48,6 +50,10 @@ function makeApp(opts: {
   } as unknown as App;
 
   return { app, fm };
+}
+
+function makeFile(path = "note.md"): { path: string; extension: string } {
+  return { path, extension: "md" };
 }
 
 function makeSettings(
@@ -217,5 +223,42 @@ describe("generateMetadata integration", () => {
     expect(fm.tags).toBeUndefined();
     expect(fm.description).toBeUndefined();
     expect(fm.title).toBeUndefined();
+  });
+
+  test("maps abort rejection to skipped result", async () => {
+    mockCreate.mockImplementationOnce(
+      (_body: unknown, requestOpts: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          if (requestOpts.signal?.aborted) {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+            return;
+          }
+          requestOpts.signal?.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        }),
+    );
+    const controller = new AbortController();
+    const { app } = makeApp({});
+    const file = makeFile();
+
+    const run = generateMetadataForFile(app, file as never, makeSettings(), {
+      signal: controller.signal,
+    });
+    controller.abort("plugin_unloaded");
+
+    const result = await run;
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") {
+      expect(result.reason).toBe("cancelled");
+    }
   });
 });

--- a/src/generateMetadata.test.ts
+++ b/src/generateMetadata.test.ts
@@ -183,4 +183,39 @@ describe("generateMetadata integration", () => {
     expect(fm.description).toBe("desc");
     expect(fm.title).toBeUndefined();
   });
+
+  test("passes abort signal to API call when provided", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [
+        {
+          type: "text",
+          text: '{"tags": "a,b", "description": "desc", "title": "T"}',
+        },
+      ],
+    });
+    const controller = new AbortController();
+    const { app } = makeApp({});
+
+    await generateMetadata(app, makeSettings(), { signal: controller.signal });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        signal: controller.signal,
+      }),
+    );
+  });
+
+  test("skips when abort signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort("plugin_unloaded");
+    const { app, fm } = makeApp({});
+
+    await generateMetadata(app, makeSettings(), { signal: controller.signal });
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(fm.tags).toBeUndefined();
+    expect(fm.description).toBeUndefined();
+    expect(fm.title).toBeUndefined();
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,15 +22,19 @@ export function migrateSettings(
 
 export default class MetadataToolPlugin extends Plugin {
   settings: MetadataToolSettings = DEFAULT_SETTINGS;
+  private runController: AbortController = new AbortController();
 
   async onload(): Promise<void> {
+    this.runController = new AbortController();
     await this.loadSettings();
 
     this.addCommand({
       id: "generate-metadata",
       name: "Generate metadata for current note",
       callback: async () => {
-        await generateMetadata(this.app, this.settings);
+        await generateMetadata(this.app, this.settings, {
+          signal: this.runController.signal,
+        });
       },
     });
 
@@ -42,9 +46,16 @@ export default class MetadataToolPlugin extends Plugin {
             .setTitle("Generate metadata (recursive)")
             .setIcon("tags")
             .onClick(async () => {
-              await runBulkForFolder(this.app, fileOrFolder, {
-                ...this.settings,
-              });
+              await runBulkForFolder(
+                this.app,
+                fileOrFolder,
+                {
+                  ...this.settings,
+                },
+                {
+                  signal: this.runController.signal,
+                },
+              );
             }),
         );
       }),
@@ -53,7 +64,9 @@ export default class MetadataToolPlugin extends Plugin {
     this.addSettingTab(new MetadataToolSettingTab(this.app, this));
   }
 
-  onunload(): void {}
+  onunload(): void {
+    this.runController.abort("plugin_unloaded");
+  }
 
   async loadSettings(): Promise<void> {
     const loadedSettings = migrateSettings(await this.loadData());

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -182,6 +182,15 @@ export interface GenerateOptions {
   signal?: AbortSignal;
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof DOMException !== "undefined" &&
+      error instanceof DOMException &&
+      error.name === "AbortError")
+  );
+}
+
 export async function generateMetadataForFile(
   app: App,
   file: TFile,
@@ -222,6 +231,9 @@ export async function generateMetadataForFile(
       ? { kind: "changed", file }
       : { kind: "skipped", file, reason: "no changes" };
   } catch (error) {
+    if (opts.signal?.aborted || isAbortError(error)) {
+      return { kind: "skipped", file, reason: "cancelled" };
+    }
     return {
       kind: "error",
       file,

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -179,6 +179,7 @@ export type FileResult =
 
 export interface GenerateOptions {
   isBulk?: boolean;
+  signal?: AbortSignal;
 }
 
 export async function generateMetadataForFile(
@@ -202,6 +203,10 @@ export async function generateMetadataForFile(
     return { kind: "skipped", file, reason: "all fields already populated" };
   }
 
+  if (opts.signal?.aborted) {
+    return { kind: "skipped", file, reason: "cancelled before request" };
+  }
+
   try {
     const updateAll = settings.updateMethod === "always_regenerate";
     const hasChanges = await addMetadataWithClaude(
@@ -211,6 +216,7 @@ export async function generateMetadataForFile(
       frontMatter,
       updateAll,
       opts.isBulk ?? false,
+      opts.signal,
     );
     return hasChanges
       ? { kind: "changed", file }
@@ -228,6 +234,7 @@ export async function generateMetadataForFile(
 export async function generateMetadata(
   app: App,
   settings: MetadataToolSettings,
+  opts: GenerateOptions = {},
 ): Promise<void> {
   const file = app.workspace.getActiveFile();
   if (!file) {
@@ -248,7 +255,9 @@ export async function generateMetadata(
     return;
   }
 
-  const result = await generateMetadataForFile(app, file, settings);
+  const result = await generateMetadataForFile(app, file, settings, {
+    signal: opts.signal,
+  });
   if (result.kind === "changed") {
     new Notice("Metadata updated successfully");
   } else if (result.kind === "error") {
@@ -264,6 +273,7 @@ async function addMetadataWithClaude(
   frontMatter: Record<string, unknown>,
   force: boolean = false,
   isBulk: boolean = false,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   const contentStr = settings.truncateContent
     ? await getContent(
@@ -284,7 +294,7 @@ async function addMetadataWithClaude(
   const notice = isBulk ? undefined : new Notice("Generating metadata...", 0);
   let response: string;
   try {
-    response = await callClaude(system, userMessage, settings);
+    response = await callClaude(system, userMessage, settings, { signal });
   } finally {
     notice?.hide();
   }
@@ -300,6 +310,10 @@ async function addMetadataWithClaude(
   }
 
   if (!response) {
+    return false;
+  }
+
+  if (signal?.aborted) {
     return false;
   }
 
@@ -365,6 +379,9 @@ async function addMetadataWithClaude(
   }
 
   for (const u of updates) {
+    if (signal?.aborted) {
+      return hasChanges;
+    }
     const resolved = resolveUpdateMethod(force, frontMatter[u.fieldName]);
     if (await writeField(u, resolved)) {
       hasChanges = true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,11 +5,17 @@ import type { MetadataToolSettings } from "./settings";
 // Output budget for the model's JSON response (tags + description + title).
 // Distinct from settings.contentTokenLimit, which bounds the input note content.
 const MAX_RESPONSE_TOKENS = 2048;
+const REQUEST_TIMEOUT_MS = 60_000;
+
+export interface CallClaudeOptions {
+  signal?: AbortSignal;
+}
 
 export async function callClaude(
   system: string,
   userMessage: string,
   settings: MetadataToolSettings,
+  options: CallClaudeOptions = {},
 ): Promise<string> {
   // Safe in Obsidian's Electron renderer — no browser security concerns apply
   const anthropic = new Anthropic({
@@ -17,12 +23,18 @@ export async function callClaude(
     dangerouslyAllowBrowser: true,
   });
 
-  const message = await anthropic.messages.create({
-    model: settings.anthropicModel,
-    max_tokens: MAX_RESPONSE_TOKENS,
-    system,
-    messages: [{ role: "user", content: userMessage }],
-  });
+  const message = await anthropic.messages.create(
+    {
+      model: settings.anthropicModel,
+      max_tokens: MAX_RESPONSE_TOKENS,
+      system,
+      messages: [{ role: "user", content: userMessage }],
+    },
+    {
+      timeout: REQUEST_TIMEOUT_MS,
+      signal: options.signal,
+    },
+  );
 
   if (message.content.length > 0 && message.content[0].type === "text") {
     return message.content[0].text;


### PR DESCRIPTION
Summary:
- add explicit Anthropic request options for timeout and abort signal support (#110)
- wire abort signals through single-note and bulk generation paths
- abort in-flight runs in plugin onunload() to stop post-disable work (#113)
- add regression tests for timeout/options forwarding and signal-aware cancellation

Verification:
- bun run check
- bun test

This PR includes two atomic commits:
1. fix: add timeout and request options to Claude API calls (#110)
2. fix: abort in-flight metadata runs on plugin unload (#113)
