### PR TITLE
Fix #115 settings validation at load trust boundary

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { migrateSettings } from "./main";
+import { DEFAULT_SETTINGS } from "./settings";
 
 describe("migrateSettings", () => {
   test("returns null for null input", () => {
@@ -38,5 +39,62 @@ describe("migrateSettings", () => {
     expect(result?.anthropicApiKey).toBe("sk-test");
     expect(result?.tagsFieldName).toBe("tags");
     expect(result?.contentTokenLimit).toBe(500);
+  });
+
+  test("normalizes invalid trust-boundary settings to defaults", () => {
+    const result = migrateSettings({
+      anthropicApiKey: 123,
+      anthropicModel: "not-a-real-model",
+      tagsFieldName: false,
+      descriptionFieldName: null,
+      titleFieldName: ["title"],
+      enableTitle: "true",
+      debugLogging: "false",
+      truncateContent: "yes",
+      contentTokenLimit: -10,
+      truncateMethod: "bogus",
+      updateMethod: "overwrite",
+      tagsPrompt: 123,
+      descriptionPrompt: false,
+      titlePrompt: null,
+    });
+
+    expect(result).toEqual(DEFAULT_SETTINGS);
+  });
+
+  test("preserves valid loaded settings", () => {
+    const result = migrateSettings({
+      anthropicApiKey: "sk-test",
+      anthropicModel: "claude-haiku-4-5-20251001",
+      tagsFieldName: "keywords",
+      descriptionFieldName: "summary",
+      titleFieldName: "headline",
+      enableTitle: false,
+      debugLogging: true,
+      truncateContent: false,
+      contentTokenLimit: 42,
+      truncateMethod: "heading",
+      updateMethod: "always_regenerate",
+      tagsPrompt: "t",
+      descriptionPrompt: "d",
+      titlePrompt: "h",
+    });
+
+    expect(result).toEqual({
+      anthropicApiKey: "sk-test",
+      anthropicModel: "claude-haiku-4-5-20251001",
+      tagsFieldName: "keywords",
+      descriptionFieldName: "summary",
+      titleFieldName: "headline",
+      enableTitle: false,
+      debugLogging: true,
+      truncateContent: false,
+      contentTokenLimit: 42,
+      truncateMethod: "heading",
+      updateMethod: "always_regenerate",
+      tagsPrompt: "t",
+      descriptionPrompt: "d",
+      titlePrompt: "h",
+    });
   });
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { migrateSettings } from "./main";
-import { DEFAULT_SETTINGS } from "./settings";
+import { DEFAULT_SETTINGS, type MetadataToolSettings } from "./settings";
 
 describe("migrateSettings", () => {
   test("returns null for null input", () => {
@@ -63,7 +63,7 @@ describe("migrateSettings", () => {
   });
 
   test("preserves valid loaded settings", () => {
-    const result = migrateSettings({
+    const validLoaded: MetadataToolSettings = {
       anthropicApiKey: "sk-test",
       anthropicModel: "claude-haiku-4-5-20251001",
       tagsFieldName: "keywords",
@@ -78,23 +78,9 @@ describe("migrateSettings", () => {
       tagsPrompt: "t",
       descriptionPrompt: "d",
       titlePrompt: "h",
-    });
+    };
+    const result = migrateSettings(validLoaded);
 
-    expect(result).toEqual({
-      anthropicApiKey: "sk-test",
-      anthropicModel: "claude-haiku-4-5-20251001",
-      tagsFieldName: "keywords",
-      descriptionFieldName: "summary",
-      titleFieldName: "headline",
-      enableTitle: false,
-      debugLogging: true,
-      truncateContent: false,
-      contentTokenLimit: 42,
-      truncateMethod: "heading",
-      updateMethod: "always_regenerate",
-      tagsPrompt: "t",
-      descriptionPrompt: "d",
-      titlePrompt: "h",
-    });
+    expect(result).toEqual({ ...DEFAULT_SETTINGS, ...validLoaded });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,16 @@
 import { Plugin, TFolder } from "obsidian";
 import { runBulkForFolder } from "./bulkOrchestrator";
 import { generateMetadata } from "./metadata";
-import { DEFAULT_SETTINGS, type MetadataToolSettings } from "./settings";
+import {
+  DEFAULT_SETTINGS,
+  type MetadataToolSettings,
+  VALID_MODEL_OPTIONS,
+  VALID_TRUNCATE_METHOD_OPTIONS,
+  VALID_UPDATE_METHOD_OPTIONS,
+} from "./settings";
 import { MetadataToolSettingTab } from "./settingsTab";
 
-const VALID_MODELS = new Set([
-  "claude-sonnet-4-6",
-  "claude-opus-4-6",
-  "claude-haiku-4-5-20251001",
-]);
-const VALID_TRUNCATE_METHODS = new Set(["head_only", "head_tail", "heading"]);
-const VALID_UPDATE_METHODS = new Set([
-  "always_regenerate",
-  "preserve_existing",
-]);
+const VALID_MODELS = new Set<string>(VALID_MODEL_OPTIONS);
 
 function readString(
   value: unknown,
@@ -35,12 +32,34 @@ function readPositiveInt(value: unknown, fallback: number): number {
     : fallback;
 }
 
-export function migrateSettings(
-  loaded: Record<string, unknown> | null,
-): MetadataToolSettings | null {
-  if (!loaded) return loaded;
+function isTruncateMethod(
+  value: string,
+): value is MetadataToolSettings["truncateMethod"] {
+  return (
+    value === VALID_TRUNCATE_METHOD_OPTIONS[0] ||
+    value === VALID_TRUNCATE_METHOD_OPTIONS[1] ||
+    value === VALID_TRUNCATE_METHOD_OPTIONS[2]
+  );
+}
 
-  const migrated = { ...loaded };
+function isUpdateMethod(
+  value: string,
+): value is MetadataToolSettings["updateMethod"] {
+  return (
+    value === VALID_UPDATE_METHOD_OPTIONS[0] ||
+    value === VALID_UPDATE_METHOD_OPTIONS[1]
+  );
+}
+
+export function migrateSettings(
+  loaded: unknown | null,
+): MetadataToolSettings | null {
+  if (!loaded || typeof loaded !== "object" || Array.isArray(loaded)) {
+    return null;
+  }
+
+  const raw = loaded as Record<string, unknown>;
+  const migrated = { ...raw };
 
   if (migrated.anthropicModel === "claude-sonnet-4-5-20250929") {
     migrated.anthropicModel = "claude-sonnet-4-6";
@@ -102,11 +121,11 @@ export function migrateSettings(
       migrated.contentTokenLimit,
       DEFAULT_SETTINGS.contentTokenLimit,
     ),
-    truncateMethod: VALID_TRUNCATE_METHODS.has(truncateMethodCandidate)
-      ? (truncateMethodCandidate as MetadataToolSettings["truncateMethod"])
+    truncateMethod: isTruncateMethod(truncateMethodCandidate)
+      ? truncateMethodCandidate
       : DEFAULT_SETTINGS.truncateMethod,
-    updateMethod: VALID_UPDATE_METHODS.has(updateMethodCandidate)
-      ? (updateMethodCandidate as MetadataToolSettings["updateMethod"])
+    updateMethod: isUpdateMethod(updateMethodCandidate)
+      ? updateMethodCandidate
       : DEFAULT_SETTINGS.updateMethod,
     tagsPrompt: readString(migrated.tagsPrompt, DEFAULT_SETTINGS.tagsPrompt),
     descriptionPrompt: readString(

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,20 +4,119 @@ import { generateMetadata } from "./metadata";
 import { DEFAULT_SETTINGS, type MetadataToolSettings } from "./settings";
 import { MetadataToolSettingTab } from "./settingsTab";
 
+const VALID_MODELS = new Set([
+  "claude-sonnet-4-6",
+  "claude-opus-4-6",
+  "claude-haiku-4-5-20251001",
+]);
+const VALID_TRUNCATE_METHODS = new Set(["head_only", "head_tail", "heading"]);
+const VALID_UPDATE_METHODS = new Set([
+  "always_regenerate",
+  "preserve_existing",
+]);
+
+function readString(
+  value: unknown,
+  fallback: string,
+  { nonEmpty = false }: { nonEmpty?: boolean } = {},
+): string {
+  if (typeof value !== "string") return fallback;
+  if (nonEmpty && value.trim() === "") return fallback;
+  return value;
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function readPositiveInt(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
 export function migrateSettings(
   loaded: Record<string, unknown> | null,
-): Record<string, unknown> | null {
+): MetadataToolSettings | null {
   if (!loaded) return loaded;
 
-  if (loaded.anthropicModel === "claude-sonnet-4-5-20250929") {
-    loaded.anthropicModel = "claude-sonnet-4-6";
+  const migrated = { ...loaded };
+
+  if (migrated.anthropicModel === "claude-sonnet-4-5-20250929") {
+    migrated.anthropicModel = "claude-sonnet-4-6";
   }
 
-  if (loaded.anthropicModel === "claude-opus-4-5-20251101") {
-    loaded.anthropicModel = "claude-opus-4-6";
+  if (migrated.anthropicModel === "claude-opus-4-5-20251101") {
+    migrated.anthropicModel = "claude-opus-4-6";
   }
 
-  return loaded;
+  const anthropicModel = readString(
+    migrated.anthropicModel,
+    DEFAULT_SETTINGS.anthropicModel,
+  );
+  const truncateMethodCandidate = readString(
+    migrated.truncateMethod,
+    DEFAULT_SETTINGS.truncateMethod,
+  );
+  const updateMethodCandidate = readString(
+    migrated.updateMethod,
+    DEFAULT_SETTINGS.updateMethod,
+  );
+
+  const normalized: MetadataToolSettings = {
+    anthropicApiKey: readString(
+      migrated.anthropicApiKey,
+      DEFAULT_SETTINGS.anthropicApiKey,
+    ),
+    anthropicModel: VALID_MODELS.has(anthropicModel)
+      ? anthropicModel
+      : DEFAULT_SETTINGS.anthropicModel,
+    tagsFieldName: readString(
+      migrated.tagsFieldName,
+      DEFAULT_SETTINGS.tagsFieldName,
+      { nonEmpty: true },
+    ),
+    descriptionFieldName: readString(
+      migrated.descriptionFieldName,
+      DEFAULT_SETTINGS.descriptionFieldName,
+      { nonEmpty: true },
+    ),
+    titleFieldName: readString(
+      migrated.titleFieldName,
+      DEFAULT_SETTINGS.titleFieldName,
+      { nonEmpty: true },
+    ),
+    enableTitle: readBoolean(
+      migrated.enableTitle,
+      DEFAULT_SETTINGS.enableTitle,
+    ),
+    debugLogging: readBoolean(
+      migrated.debugLogging,
+      DEFAULT_SETTINGS.debugLogging,
+    ),
+    truncateContent: readBoolean(
+      migrated.truncateContent,
+      DEFAULT_SETTINGS.truncateContent,
+    ),
+    contentTokenLimit: readPositiveInt(
+      migrated.contentTokenLimit,
+      DEFAULT_SETTINGS.contentTokenLimit,
+    ),
+    truncateMethod: VALID_TRUNCATE_METHODS.has(truncateMethodCandidate)
+      ? (truncateMethodCandidate as MetadataToolSettings["truncateMethod"])
+      : DEFAULT_SETTINGS.truncateMethod,
+    updateMethod: VALID_UPDATE_METHODS.has(updateMethodCandidate)
+      ? (updateMethodCandidate as MetadataToolSettings["updateMethod"])
+      : DEFAULT_SETTINGS.updateMethod,
+    tagsPrompt: readString(migrated.tagsPrompt, DEFAULT_SETTINGS.tagsPrompt),
+    descriptionPrompt: readString(
+      migrated.descriptionPrompt,
+      DEFAULT_SETTINGS.descriptionPrompt,
+    ),
+    titlePrompt: readString(migrated.titlePrompt, DEFAULT_SETTINGS.titlePrompt),
+  };
+
+  return normalized;
 }
 
 export default class MetadataToolPlugin extends Plugin {
@@ -70,7 +169,7 @@ export default class MetadataToolPlugin extends Plugin {
 
   async loadSettings(): Promise<void> {
     const loadedSettings = migrateSettings(await this.loadData());
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, loadedSettings);
+    this.settings = { ...(loadedSettings ?? DEFAULT_SETTINGS) };
   }
 
   async saveSettings(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,49 @@ export interface MetadataToolSettings {
   titlePrompt: string;
 }
 
+export const VALID_MODEL_OPTIONS = [
+  "claude-sonnet-4-6",
+  "claude-opus-4-6",
+  "claude-haiku-4-5-20251001",
+] as const;
+
+export const MODEL_OPTION_LABELS: Record<
+  (typeof VALID_MODEL_OPTIONS)[number],
+  string
+> = {
+  "claude-sonnet-4-6": "Claude Sonnet 4.6",
+  "claude-opus-4-6": "Claude Opus 4.6",
+  "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+};
+
+export const VALID_TRUNCATE_METHOD_OPTIONS = [
+  "head_only",
+  "head_tail",
+  "heading",
+] as const;
+
+export const TRUNCATE_METHOD_LABELS: Record<
+  (typeof VALID_TRUNCATE_METHOD_OPTIONS)[number],
+  string
+> = {
+  head_only: "Beginning Only",
+  head_tail: "Beginning + End",
+  heading: "Headings + Summaries",
+};
+
+export const VALID_UPDATE_METHOD_OPTIONS = [
+  "always_regenerate",
+  "preserve_existing",
+] as const;
+
+export const UPDATE_METHOD_LABELS: Record<
+  (typeof VALID_UPDATE_METHOD_OPTIONS)[number],
+  string
+> = {
+  always_regenerate: "Always Regenerate",
+  preserve_existing: "Preserve Existing",
+};
+
 export const DEFAULT_SETTINGS: MetadataToolSettings = {
   anthropicApiKey: "",
   anthropicModel: "claude-sonnet-4-6",

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,5 +1,13 @@
 import { type App, Notice, PluginSettingTab, Setting } from "obsidian";
 import type MetadataToolPlugin from "./main";
+import {
+  MODEL_OPTION_LABELS,
+  TRUNCATE_METHOD_LABELS,
+  UPDATE_METHOD_LABELS,
+  VALID_MODEL_OPTIONS,
+  VALID_TRUNCATE_METHOD_OPTIONS,
+  VALID_UPDATE_METHOD_OPTIONS,
+} from "./settings";
 
 export class MetadataToolSettingTab extends PluginSettingTab {
   plugin: MetadataToolPlugin;
@@ -40,17 +48,17 @@ export class MetadataToolSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Model")
       .setDesc("Model to use for metadata generation")
-      .addDropdown((dropdown) =>
+      .addDropdown((dropdown) => {
+        for (const model of VALID_MODEL_OPTIONS) {
+          dropdown.addOption(model, MODEL_OPTION_LABELS[model]);
+        }
         dropdown
-          .addOption("claude-sonnet-4-6", "Claude Sonnet 4.6")
-          .addOption("claude-opus-4-6", "Claude Opus 4.6")
-          .addOption("claude-haiku-4-5-20251001", "Claude Haiku 4.5")
           .setValue(this.plugin.settings.anthropicModel)
           .onChange(async (value) => {
             this.plugin.settings.anthropicModel = value;
             await this.plugin.saveSettings();
-          }),
-      );
+          });
+      });
 
     new Setting(containerEl)
       .setName("Debug Logging")
@@ -74,18 +82,19 @@ export class MetadataToolSettingTab extends PluginSettingTab {
       .setDesc(
         "Always Regenerate: regenerate on every command; Preserve Existing: only generate empty fields",
       )
-      .addDropdown((dropdown) =>
+      .addDropdown((dropdown) => {
+        for (const method of VALID_UPDATE_METHOD_OPTIONS) {
+          dropdown.addOption(method, UPDATE_METHOD_LABELS[method]);
+        }
         dropdown
-          .addOption("always_regenerate", "Always Regenerate")
-          .addOption("preserve_existing", "Preserve Existing")
           .setValue(this.plugin.settings.updateMethod)
           .onChange(async (value) => {
             this.plugin.settings.updateMethod = value as
               | "always_regenerate"
               | "preserve_existing";
             await this.plugin.saveSettings();
-          }),
-      );
+          });
+      });
 
     new Setting(containerEl)
       .setName("Truncate Content")
@@ -122,11 +131,11 @@ export class MetadataToolSettingTab extends PluginSettingTab {
     const truncateMethodSetting = new Setting(containerEl)
       .setName("Truncate Method")
       .setDesc("How to truncate long content")
-      .addDropdown((dropdown) =>
+      .addDropdown((dropdown) => {
+        for (const method of VALID_TRUNCATE_METHOD_OPTIONS) {
+          dropdown.addOption(method, TRUNCATE_METHOD_LABELS[method]);
+        }
         dropdown
-          .addOption("head_only", "Beginning Only")
-          .addOption("head_tail", "Beginning + End")
-          .addOption("heading", "Headings + Summaries")
           .setValue(this.plugin.settings.truncateMethod)
           .onChange(async (value) => {
             this.plugin.settings.truncateMethod = value as
@@ -134,8 +143,8 @@ export class MetadataToolSettingTab extends PluginSettingTab {
               | "head_tail"
               | "heading";
             await this.plugin.saveSettings();
-          }),
-      );
+          });
+      });
 
     contentTokenLimitSetting.setDisabled(!this.plugin.settings.truncateContent);
     truncateMethodSetting.setDisabled(!this.plugin.settings.truncateContent);


### PR DESCRIPTION
Summary:
- harden migrateSettings to normalize untrusted loaded settings into a valid settings object
- keep legacy model migrations and then validate all loaded fields
- enforce domain checks for model/truncate/update enums
- enforce type checks for booleans/strings and positive integer token limit
- fallback invalid values to DEFAULT_SETTINGS
- add regression tests for invalid-load normalization and valid-load preservation

Verification:
- bun test src/main.test.ts
- bun run check
- bun test
