### PR TITLE
docs: sync Data Flow section with tool-use refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,8 @@ Tests are colocated with source files in `src/`:
 1. User runs "Generate metadata for current note" command
 2. `generateMetadata()` checks which fields need population based on `updateMethod`
 3. Content is extracted and optionally truncated via `getContent()`
-4. `callClaude()` sends the prompt to the Anthropic API
-5. Response JSON is extracted with regex and parsed
+4. `callClaudeForMetadata()` sends the prompt to the Anthropic API with a forced `submit_metadata` tool call
+5. The model's `tool_use` block input is validated against the schema and returned as `MetadataFields`
 6. `updateFrontMatter()` writes each field via `processFrontMatter()`
 
 ### Key Patterns


### PR DESCRIPTION
## Summary

\`CLAUDE.md\` still described the pre-refactor regex-based JSON parse and called the function \`callClaude()\`. Both have been wrong since the structured tool-use refactor (b20171d / 7085386).

- Bullet 4: \`callClaude()\` → \`callClaudeForMetadata()\` with a forced \`submit_metadata\` tool call.
- Bullet 5: regex-extracted JSON → validated \`tool_use\` block input returned as \`MetadataFields\`.

Two-line doc fix; no code touched.